### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This repository contains the source code for a confluence context server.
 For now, the server only contains prompts aimed to be used as slash commands by Zed.
 
+<a href="https://glama.ai/mcp/servers/qkapsouyfx"><img width="380" height="200" src="https://glama.ai/mcp/servers/qkapsouyfx/badge" alt="mcp-confluence MCP server" /></a>
+
 # Installation
 ```bash
 npm install -g mcp-confluence


### PR DESCRIPTION
This PR adds a badge for the [mcp-confluence](https://glama.ai/mcp/servers/qkapsouyfx) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/qkapsouyfx"><img width="380" height="200" src="https://glama.ai/mcp/servers/qkapsouyfx/badge" alt="mcp-confluence MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.